### PR TITLE
Add state monitors

### DIFF
--- a/.changeset/wicked-scissors-shake.md
+++ b/.changeset/wicked-scissors-shake.md
@@ -1,0 +1,29 @@
+---
+'hine': patch
+---
+
+Hine now requires that action definitions as well entry and exit actions be defined in an external
+monitor. This allows you create different side-effect implementations for the same state machine!
+
+Before:
+
+```javascript
+const state = h.atomic({
+	actions: {
+		action: h.action(() => console.log('action!')),
+  	}
+  	entry: [{ actions: ['action'] }],
+});
+```
+
+After:
+
+```javascript
+const state = h.atomic();
+state.monitor({
+	actions: {
+		action: h.action(() => console.log('action!')),
+	}
+	entry: [{ actions: ['action'] }],
+});
+```

--- a/packages/hine/src/base.js
+++ b/packages/hine/src/base.js
@@ -51,8 +51,11 @@ export class BaseState {
 	/** @type {import('./action.js').Action | null} */
 	#action = null;
 	#actionConfig;
-	/** Actions from the user config */
-	#actions;
+	/**
+	 * Actions from the user config
+	 * @type {Record<string, import('./action.js').Action>}
+	 */
+	#actions = {};
 	/**
 	 * Actions from all ancestor states and the config
 	 * @type {Record<string, import('./action').Action>}
@@ -103,7 +106,6 @@ export class BaseState {
 	 * @param {import('./types.js').AtomicStateConfig} [stateConfig]
 	 */
 	constructor(stateConfig) {
-		this.#actions = stateConfig?.actions || {};
 		this.#actionConfig = stateConfig?.actionConfig || {};
 		this.#alwaysConfig = stateConfig?.always || [];
 		this.#conditions = stateConfig?.conditions || {};
@@ -265,6 +267,14 @@ export class BaseState {
 				|| (this.#condition && path === this.#condition.path.join('.'))
 				|| (this.#handler && path === this.#handler.path.join('.')),
 		);
+	}
+	/** @param {import('./types.js').MonitorConfig} config */
+	monitor(config) {
+		if (config.actions) {
+			for (const [name, action] of Object.entries(config.actions)) {
+				this.#actions[name] = action;
+			}
+		}
 	}
 	get name() {
 		return this.#name;

--- a/packages/hine/src/base.js
+++ b/packages/hine/src/base.js
@@ -76,12 +76,14 @@ export class BaseState {
 	#conditions;
 	/** @type {Handler[]} */
 	#entry = [];
-	#entryConfig;
+	/** @type {EntryHandlerConfig[]} */
+	#entryConfig = [];
 	/** @type {StateEvent | null} */
 	#event = null;
 	/** @type {Handler[]} */
 	#exit = [];
-	#exitConfig;
+	/** @type {ExitHandlerConfig[]} */
+	#exitConfig = [];
 	/**
 	 * The active handler that is currently executing
 	 *
@@ -110,8 +112,6 @@ export class BaseState {
 		this.#alwaysConfig = stateConfig?.always || [];
 		this.#conditions = stateConfig?.conditions || {};
 		this.#conditionConfig = stateConfig?.conditionConfig || {};
-		this.#entryConfig = stateConfig?.entry || [];
-		this.#exitConfig = stateConfig?.exit || [];
 		this.#name = stateConfig?.name || '';
 		this.#onConfig = stateConfig?.on || {};
 	}
@@ -273,6 +273,16 @@ export class BaseState {
 		if (config.actions) {
 			for (const [name, action] of Object.entries(config.actions)) {
 				this.#actions[name] = action;
+			}
+		}
+		if (config.entry) {
+			for (const handler of config.entry) {
+				this.#entryConfig.push(handler);
+			}
+		}
+		if (config.exit) {
+			for (const handler of config.exit) {
+				this.#exitConfig.push(handler);
 			}
 		}
 	}

--- a/packages/hine/src/compound.js
+++ b/packages/hine/src/compound.js
@@ -61,6 +61,24 @@ export class CompoundState extends BaseState {
 			|| (path.startsWith(`${this.name}.`) && this.#state.matches(path.slice(this.name.length + 1)))
 		);
 	}
+	/** @param {import('./types.js').CompoundMonitorConfig} config */
+	monitor(config) {
+		super.monitor(config);
+		if (!config?.states) return;
+		for (const [name, monitorConfig] of Object.entries(config.states)) {
+			const state = this.#states.get(name);
+			if (!state) {
+				const parentPath = this.parent?.path || [];
+				const pathString = parentPath.length
+					? `${parentPath.join('.')}.${name}`
+					: name;
+				throw Error(
+					`State '${pathString}' defined on monitor does not exist in state tree. Expected one of: ${[...this.#states.keys()].join(', ')}`,
+				);
+			}
+			state.monitor(monitorConfig);
+		}
+	}
 	get state() {
 		return this.#state;
 	}

--- a/packages/hine/src/compound.spec.js
+++ b/packages/hine/src/compound.spec.js
@@ -7,37 +7,43 @@ import { Condition } from './condition.js';
 describe('htstate', () => {
 	describe('missing actions', () => {
 		it('throws on missing entry actions', () => {
-			expect(() => new CompoundState({
-					states: {
-						first: new CompoundState({
-							entry: [
-								{
-									actions: ['missing'],
-								},
-							],
-							states: {
-								s1: new AtomicState(),
-							},
-						}),
+			const state = new CompoundState({
+				states: {
+					first: new CompoundState({
+						states: {
+							s1: new AtomicState(),
+						},
+					}),
+				},
+			});
+			state.monitor({
+				entry: [
+					{
+						actions: ['missing'],
 					},
-				}).start(),).toThrow('\'missing\'');
+				],
+			});
+			expect(() => state.start()).toThrow('\'missing\'');
 		});
 
 		it('throws on missing exit actions', () => {
-			expect(() => new CompoundState({
-					states: {
-						first: new CompoundState({
-							exit: [
-								{
-									actions: ['missing'],
-								},
-							],
-							states: {
-								s1: new AtomicState(),
-							},
-						}),
+			const state = new CompoundState({
+				states: {
+					first: new CompoundState({
+						states: {
+							s1: new AtomicState(),
+						},
+					}),
+				},
+			});
+			state.monitor({
+				exit: [
+					{
+						actions: ['missing'],
 					},
-				}).start(),).toThrow('\'missing\'');
+				],
+			});
+			expect(() => state.start()).toThrow('\'missing\'');
 		});
 
 		it('throws on missing transient actions', () => {
@@ -75,32 +81,6 @@ describe('htstate', () => {
 							},
 							{
 								actions: ['always'],
-							},
-							{
-								actions: ['ignore'],
-								condition: 'ignore',
-							},
-						],
-						entry: [
-							{
-								actions: ['entry'],
-								condition: 'run',
-							},
-							{
-								actions: ['entry'],
-							},
-							{
-								actions: ['ignore'],
-								condition: 'ignore',
-							},
-						],
-						exit: [
-							{
-								actions: ['exit'],
-								condition: 'run',
-							},
-							{
-								actions: ['exit'],
 							},
 							{
 								actions: ['ignore'],
@@ -168,6 +148,32 @@ describe('htstate', () => {
 								},
 							}),
 						},
+						entry: [
+							{
+								actions: ['entry'],
+								condition: 'run',
+							},
+							{
+								actions: ['entry'],
+							},
+							{
+								actions: ['ignore'],
+								condition: 'ignore',
+							},
+						],
+						exit: [
+							{
+								actions: ['exit'],
+								condition: 'run',
+							},
+							{
+								actions: ['exit'],
+							},
+							{
+								actions: ['ignore'],
+								condition: 'ignore',
+							},
+						],
 					},
 				},
 			});

--- a/packages/hine/src/compound.spec.js
+++ b/packages/hine/src/compound.spec.js
@@ -122,6 +122,25 @@ describe('htstate', () => {
 								},
 							],
 						},
+						conditions: {
+							run: new Condition({
+								run() {
+									return true;
+								},
+							}),
+							ignore: new Condition({
+								run() {
+									return false;
+								},
+							}),
+						},
+					}),
+					other: new AtomicState(),
+				},
+			});
+			machine.monitor({
+				states: {
+					current: {
 						actions: {
 							ignore: new Action({
 								run() {
@@ -149,22 +168,10 @@ describe('htstate', () => {
 								},
 							}),
 						},
-						conditions: {
-							run: new Condition({
-								run() {
-									return true;
-								},
-							}),
-							ignore: new Condition({
-								run() {
-									return false;
-								},
-							}),
-						},
-					}),
-					other: new AtomicState(),
+					},
 				},
-			}).start();
+			});
+			machine.start();
 		});
 
 		it('ignores initial entry then transient actions', () => {

--- a/packages/hine/src/types.ts
+++ b/packages/hine/src/types.ts
@@ -54,7 +54,6 @@ export type StateNode = AtomicState | CompoundState;
 
 type StateNodeConfig = {
 	actionConfig: Partial<Omit<ActionConfig, 'run'>>;
-	actions: Record<string, Action>;
 	always: AlwaysHandlerConfig[];
 	conditionConfig: Partial<Omit<ConditionConfig, 'run'>>;
 	conditions: Record<string, Condition>;
@@ -89,5 +88,13 @@ export type StateNodeJSON = AtomicStateJSON | CompoundStateJSON;
 export type ActionJSON = ReturnType<Action['toJSON']>;
 export type ConditionJSON = ReturnType<Condition['toJSON']>;
 export type HandlerJSON = ReturnType<Handler['toJSON']>;
+
+export type MonitorConfig = {
+	actions?: Record<string, Action>;
+}
+
+export type CompoundMonitorConfig = MonitorConfig & {
+	states?: Record<string, MonitorConfig | CompoundMonitorConfig>;
+}
 
 export {};

--- a/packages/hine/src/types.ts
+++ b/packages/hine/src/types.ts
@@ -57,8 +57,6 @@ type StateNodeConfig = {
 	always: AlwaysHandlerConfig[];
 	conditionConfig: Partial<Omit<ConditionConfig, 'run'>>;
 	conditions: Record<string, Condition>;
-	entry: EntryHandlerConfig[];
-	exit: ExitHandlerConfig[];
 	name: string;
 	on: Record<string, DispatchHandlerConfig[]>;
 };
@@ -91,6 +89,8 @@ export type HandlerJSON = ReturnType<Handler['toJSON']>;
 
 export type MonitorConfig = {
 	actions?: Record<string, Action>;
+	entry?: EntryHandlerConfig[];
+	exit?: ExitHandlerConfig[];
 }
 
 export type CompoundMonitorConfig = MonitorConfig & {

--- a/packages/hine/tests/action/path.test.js
+++ b/packages/hine/tests/action/path.test.js
@@ -20,10 +20,9 @@ describe('path', () => {
 			name: 'action',
 			run() {},
 		});
-		new AtomicState({
-			name: 'state',
-			actions: { action },
-		}).start();
+		const state = new AtomicState({ name: 'state' });
+		state.monitor({ actions: { action }});
+		state.start();
 		expect(action.path).toEqual(['state', '(action)']);
 	});
 });

--- a/packages/hine/tests/atomic/actions.test.js
+++ b/packages/hine/tests/atomic/actions.test.js
@@ -7,8 +7,20 @@ describe('actions', () => {
 	it('runs initial entry then transient actions', () => {
 		/** @type {string[]} */
 		const log = [];
-		new AtomicState({
+		const state = new AtomicState({
 			name: 's0',
+			always: [
+				{
+					actions: ['always0'],
+				},
+			],
+			entry: [
+				{
+					actions: ['entry0'],
+				},
+			],
+		});
+		state.monitor({
 			actions: {
 				always0: new Action({
 					run() {
@@ -21,24 +33,15 @@ describe('actions', () => {
 					},
 				}),
 			},
-			always: [
-				{
-					actions: ['always0'],
-				},
-			],
-			entry: [
-				{
-					actions: ['entry0'],
-				},
-			],
-		}).start();
+		});
+		state.start();
 		expect(log).toEqual(['entry0', 'always0']);
 	});
 
 	it('runs entry then always actions on transition', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				a: new AtomicState({
 					on: {
@@ -50,18 +53,6 @@ describe('actions', () => {
 					},
 				}),
 				b: new AtomicState({
-					actions: {
-						always0: new Action({
-							run() {
-								log.push('always0');
-							},
-						}),
-						entry0: new Action({
-							run() {
-								log.push('entry0');
-							},
-						}),
-					},
 					always: [
 						{
 							actions: ['always0'],
@@ -74,22 +65,34 @@ describe('actions', () => {
 					],
 				}),
 			},
-		}).start();
-		machine.dispatch('event');
+		});
+		state.monitor({
+			states: {
+				b: {
+					actions: {
+						always0: new Action({
+							run() {
+								log.push('always0');
+							},
+						}),
+						entry0: new Action({
+							run() {
+								log.push('entry0');
+							},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
+		state.dispatch('event');
 		expect(log).toEqual(['entry0', 'always0']);
 	});
 
 	it('runs exit actions with leaves first and root last', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
-			actions: {
-				exit0: new Action({
-					run() {
-						log.push('exit0');
-					},
-				}),
-			},
+		const state = new CompoundState({
 			exit: [
 				{
 					actions: ['exit0'],
@@ -97,13 +100,6 @@ describe('actions', () => {
 			],
 			states: {
 				s1: new AtomicState({
-					actions: {
-						exit1: new Action({
-							run() {
-								log.push('exit1');
-							},
-						}),
-					},
 					exit: [
 						{
 							actions: ['exit1'],
@@ -119,10 +115,31 @@ describe('actions', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				exit0: new Action({
+					run() {
+						log.push('exit0');
+					},
+				}),
+			},
+			states: {
+				s1: {
+					actions: {
+						exit1: new Action({
+							run() {
+								log.push('exit1');
+							},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
 		log.length = 0;
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['exit1']);
 	});
 
@@ -130,13 +147,6 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const machine = new AtomicState({
-			actions: {
-				on0: new Action({
-					run() {
-						log.push('on0');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -144,7 +154,17 @@ describe('actions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		machine.monitor({
+			actions: {
+				on0: new Action({
+					run() {
+						log.push('on0');
+					},
+				}),
+			},
+		});
+		machine.start();
 		log.length = 0;
 
 		machine.dispatch('event');
@@ -155,18 +175,6 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const machine = new AtomicState({
-			actions: {
-				always0: new Action({
-					run() {
-						log.push('always0');
-					},
-				}),
-				on0: new Action({
-					run() {
-						log.push('on0');
-					},
-				}),
-			},
 			always: [
 				{
 					actions: ['always0'],
@@ -179,7 +187,22 @@ describe('actions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		machine.monitor({
+			actions: {
+				always0: new Action({
+					run() {
+						log.push('always0');
+					},
+				}),
+				on0: new Action({
+					run() {
+						log.push('on0');
+					},
+				}),
+			},
+		});
+		machine.start();
 		log.length = 0;
 
 		machine.dispatch('event');
@@ -192,18 +215,6 @@ describe('actions', () => {
 		const machine = new CompoundState({
 			states: {
 				s1: new AtomicState({
-					actions: {
-						exit1: new Action({
-							run() {
-								log.push('exit1');
-							},
-						}),
-						on1: new Action({
-							run() {
-								log.push('on1');
-							},
-						}),
-					},
 					exit: [
 						{
 							actions: ['exit1'],
@@ -219,6 +230,36 @@ describe('actions', () => {
 					},
 				}),
 				s2: new AtomicState({
+					always: [
+						{
+							actions: ['always2'],
+						},
+					],
+					entry: [
+						{
+							actions: ['entry2'],
+						},
+					],
+				}),
+			},
+		});
+		machine.monitor({
+			states: {
+				s1: {
+					actions: {
+						exit1: new Action({
+							run() {
+								log.push('exit1');
+							},
+						}),
+						on1: new Action({
+							run() {
+								log.push('on1');
+							},
+						}),
+					},
+				},
+				s2: {
 					actions: {
 						always2: new Action({
 							run() {
@@ -236,19 +277,10 @@ describe('actions', () => {
 							},
 						}),
 					},
-					always: [
-						{
-							actions: ['always2'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry2'],
-						},
-					],
-				}),
+				},
 			},
-		}).start();
+		});
+		machine.start();
 		log.length = 0;
 
 		machine.dispatch('event');
@@ -257,12 +289,14 @@ describe('actions', () => {
 
 	it('runs always actions on unhandled events', () => {
 		let alwaysCount = 0;
-		const machine = new AtomicState({
+		const state = new AtomicState({
 			always: [
 				{
 					actions: ['always'],
 				},
 			],
+		});
+		state.monitor({
 			actions: {
 				always: new Action({
 					run() {
@@ -270,40 +304,19 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.start();
 		expect(alwaysCount).toBe(1);
 
-		machine.dispatch('non-existent');
+		state.dispatch('non-existent');
 		expect(alwaysCount).toBe(2);
 	});
 
 	it('runs actions on ancestors', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 's0',
-			actions: {
-				always: new Action({
-					run() {
-						log.push('always');
-					},
-				}),
-				entry: new Action({
-					run() {
-						log.push('entry');
-					},
-				}),
-				exit: new Action({
-					run() {
-						log.push('exit');
-					},
-				}),
-				on: new Action({
-					run() {
-						log.push('on');
-					},
-				}),
-			},
 			states: {
 				s1: new CompoundState({
 					states: {
@@ -336,63 +349,44 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				always: new Action({
+					run() {
+						log.push('always');
+					},
+				}),
+				entry: new Action({
+					run() {
+						log.push('entry');
+					},
+				}),
+				exit: new Action({
+					run() {
+						log.push('exit');
+					},
+				}),
+				on: new Action({
+					run() {
+						log.push('on');
+					},
+				}),
+			},
+		});
+		state.start();
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['entry', 'always', 'exit', 'on']);
 	});
 
 	it('does not run parent actions if own action matches', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 's0',
-			actions: {
-				always: new Action({
-					run() {
-						log.push('not always');
-					},
-				}),
-				entry: new Action({
-					run() {
-						log.push('not entry');
-					},
-				}),
-				exit: new Action({
-					run() {
-						log.push('not exit');
-					},
-				}),
-				on: new Action({
-					run() {
-						log.push('not on');
-					},
-				}),
-			},
 			states: {
 				s1: new AtomicState({
-					actions: {
-						always: new Action({
-							run() {
-								log.push('always');
-							},
-						}),
-						entry: new Action({
-							run() {
-								log.push('entry');
-							},
-						}),
-						exit: new Action({
-							run() {
-								log.push('exit');
-							},
-						}),
-						on: new Action({
-							run() {
-								log.push('on');
-							},
-						}),
-					},
 					always: [
 						{
 							actions: ['always'],
@@ -419,9 +413,60 @@ describe('actions', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				always: new Action({
+					run() {
+						log.push('not always');
+					},
+				}),
+				entry: new Action({
+					run() {
+						log.push('not entry');
+					},
+				}),
+				exit: new Action({
+					run() {
+						log.push('not exit');
+					},
+				}),
+				on: new Action({
+					run() {
+						log.push('not on');
+					},
+				}),
+			},
+			states: {
+				s1: {
+					actions: {
+						always: new Action({
+							run() {
+								log.push('always');
+							},
+						}),
+						entry: new Action({
+							run() {
+								log.push('entry');
+							},
+						}),
+						exit: new Action({
+							run() {
+								log.push('exit');
+							},
+						}),
+						on: new Action({
+							run() {
+								log.push('on');
+							},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['entry', 'always', 'exit', 'on']);
 	});
 	it('calls actions with self-reference', () => {
@@ -432,14 +477,16 @@ describe('actions', () => {
 			},
 		});
 		const state = new AtomicState({
-			actions: {
-				action,
-			},
 			entry: [
 				{
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
+			actions: {
+				action,
+			},
 		});
 		state.start();
 	});
@@ -447,6 +494,15 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new AtomicState({
+			on: {
+				event: [
+					{
+						actions: ['action'],
+					},
+				],
+			},
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					notifyBefore: true,
@@ -454,13 +510,6 @@ describe('actions', () => {
 						log.push('action');
 					},
 				}),
-			},
-			on: {
-				event: [
-					{
-						actions: ['action'],
-					},
-				],
 			},
 		});
 		state.start();
@@ -477,6 +526,15 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new AtomicState({
+			on: {
+				event: [
+					{
+						actions: ['action'],
+					},
+				],
+			},
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					notifyAfter: true,
@@ -485,14 +543,8 @@ describe('actions', () => {
 					},
 				}),
 			},
-			on: {
-				event: [
-					{
-						actions: ['action'],
-					},
-				],
-			},
-		}).start();
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -509,13 +561,6 @@ describe('actions', () => {
 			actionConfig: {
 				notifyBefore: true,
 			},
-			actions: {
-				action: new Action({
-					run() {
-						log.push('action');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -523,7 +568,17 @@ describe('actions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					run() {
+						log.push('action');
+					},
+				}),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -540,6 +595,15 @@ describe('actions', () => {
 			actionConfig: {
 				notifyBefore: true,
 			},
+			on: {
+				event: [
+					{
+						actions: ['action'],
+					},
+				],
+			},
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					notifyBefore: false,
@@ -548,14 +612,8 @@ describe('actions', () => {
 					},
 				}),
 			},
-			on: {
-				event: [
-					{
-						actions: ['action'],
-					},
-				],
-			},
-		}).start();
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -572,14 +630,6 @@ describe('actions', () => {
 				s1: new CompoundState({
 					states: {
 						s11: new AtomicState({
-							actions: {
-								action: new Action({
-									run() {
-										log.push('action');
-										return true;
-									},
-								}),
-							},
 							on: {
 								event: [
 									{
@@ -591,7 +641,25 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					states: {
+						s11: {
+							actions: {
+								action: new Action({
+									run() {
+										log.push('action');
+									},
+								}),
+							},
+						}
+					}
+				}
+			}
+		});
+		state.start();
 		state.subscribe(() => {
 			log.push('sub');
 		});
@@ -605,12 +673,6 @@ describe('actions', () => {
 	});
 	it('resolves action using most specific configured name', () => {
 		const state = new AtomicState({
-			actions: {
-				action: new Action({
-					name: 'other-action',
-					run() {},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -619,20 +681,30 @@ describe('actions', () => {
 				],
 			},
 		});
-		expect(() => state.start()).toThrow(/unknown action/);
-		const state2 = new AtomicState({
+		state.monitor({
 			actions: {
 				action: new Action({
 					name: 'other-action',
 					run() {},
 				}),
 			},
+		});
+		expect(() => state.start()).toThrow(/unknown action/);
+		const state2 = new AtomicState({
 			on: {
 				event: [
 					{
 						actions: ['other-action'],
 					},
 				],
+			},
+		});
+		state2.monitor({
+			actions: {
+				action: new Action({
+					name: 'other-action',
+					run() {},
+				}),
 			},
 		});
 		expect(() => state2.start()).not.toThrow();
@@ -645,14 +717,16 @@ describe('actions', () => {
 			},
 		});
 		const state = new AtomicState({
-			actions: {
-				action,
-			},
 			entry: [
 				{
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
+			actions: {
+				action,
+			},
 		});
 		expect(state.action).toBe(null);
 		state.start();
@@ -662,12 +736,14 @@ describe('actions', () => {
 		const action2 = new Action({
 			run: () => 'test',
 		});
-		new AtomicState({
+		const state = new AtomicState({
 			entry: [
 				{
 					actions: ['action1'],
 				},
 			],
+		});
+		state.monitor({
 			actions: {
 				action1: new Action({
 					run({ ownerState }) {
@@ -679,13 +755,16 @@ describe('actions', () => {
 				}),
 				action2,
 			},
-		}).start();
+		});
+		state.start();
 	});
 	it('calls actions with value', () => {
 		const state = new AtomicState({
 			on: {
 				event: [{ actions: ['action']}],
 			},
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					run({ value }) {
@@ -693,7 +772,8 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.start();
 
 		state.dispatch('event', 'my-value');
 	});

--- a/packages/hine/tests/atomic/actions.test.js
+++ b/packages/hine/tests/atomic/actions.test.js
@@ -14,11 +14,6 @@ describe('actions', () => {
 					actions: ['always0'],
 				},
 			],
-			entry: [
-				{
-					actions: ['entry0'],
-				},
-			],
 		});
 		state.monitor({
 			actions: {
@@ -33,6 +28,11 @@ describe('actions', () => {
 					},
 				}),
 			},
+			entry: [
+				{
+					actions: ['entry0'],
+				},
+			],
 		});
 		state.start();
 		expect(log).toEqual(['entry0', 'always0']);
@@ -58,11 +58,6 @@ describe('actions', () => {
 							actions: ['always0'],
 						},
 					],
-					entry: [
-						{
-							actions: ['entry0'],
-						},
-					],
 				}),
 			},
 		});
@@ -81,6 +76,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry0'],
+						},
+					],
 				},
 			},
 		});
@@ -93,18 +93,8 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new CompoundState({
-			exit: [
-				{
-					actions: ['exit0'],
-				},
-			],
 			states: {
 				s1: new AtomicState({
-					exit: [
-						{
-							actions: ['exit1'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -124,6 +114,11 @@ describe('actions', () => {
 					},
 				}),
 			},
+			exit: [
+				{
+					actions: ['exit0'],
+				},
+			],
 			states: {
 				s1: {
 					actions: {
@@ -133,6 +128,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					exit: [
+						{
+							actions: ['exit1'],
+						},
+					],
 				},
 			},
 		});
@@ -215,11 +215,6 @@ describe('actions', () => {
 		const machine = new CompoundState({
 			states: {
 				s1: new AtomicState({
-					exit: [
-						{
-							actions: ['exit1'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -233,11 +228,6 @@ describe('actions', () => {
 					always: [
 						{
 							actions: ['always2'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry2'],
 						},
 					],
 				}),
@@ -258,6 +248,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					exit: [
+						{
+							actions: ['exit1'],
+						},
+					],
 				},
 				s2: {
 					actions: {
@@ -277,6 +272,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry2'],
+						},
+					],
 				},
 			},
 		});
@@ -326,16 +326,6 @@ describe('actions', () => {
 									actions: ['always'],
 								},
 							],
-							entry: [
-								{
-									actions: ['entry'],
-								},
-							],
-							exit: [
-								{
-									actions: ['exit'],
-								},
-							],
 							on: {
 								event: [
 									{
@@ -373,6 +363,24 @@ describe('actions', () => {
 					},
 				}),
 			},
+			states: {
+				s1: {
+					states: {
+						s11: {
+							entry: [
+								{
+									actions: ['entry'],
+								},
+							],
+							exit: [
+								{
+									actions: ['exit'],
+								},
+							],
+						},
+					},
+				},
+			},
 		});
 		state.start();
 
@@ -390,16 +398,6 @@ describe('actions', () => {
 					always: [
 						{
 							actions: ['always'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry'],
-						},
-					],
-					exit: [
-						{
-							actions: ['exit'],
 						},
 					],
 					on: {
@@ -461,6 +459,16 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry'],
+						},
+					],
+					exit: [
+						{
+							actions: ['exit'],
+						},
+					],
 				},
 			},
 		});
@@ -476,17 +484,16 @@ describe('actions', () => {
 				expect(value).toBe(action);
 			},
 		});
-		const state = new AtomicState({
+		const state = new AtomicState();
+		state.monitor({
+			actions: {
+				action,
+			},
 			entry: [
 				{
 					actions: ['action'],
 				},
 			],
-		});
-		state.monitor({
-			actions: {
-				action,
-			},
 		});
 		state.start();
 	});
@@ -716,17 +723,16 @@ describe('actions', () => {
 				expect(state.action).toBe(action);
 			},
 		});
-		const state = new AtomicState({
+		const state = new AtomicState();
+		state.monitor({
+			actions: {
+				action,
+			},
 			entry: [
 				{
 					actions: ['action'],
 				},
 			],
-		});
-		state.monitor({
-			actions: {
-				action,
-			},
 		});
 		expect(state.action).toBe(null);
 		state.start();
@@ -736,13 +742,7 @@ describe('actions', () => {
 		const action2 = new Action({
 			run: () => 'test',
 		});
-		const state = new AtomicState({
-			entry: [
-				{
-					actions: ['action1'],
-				},
-			],
-		});
+		const state = new AtomicState();
 		state.monitor({
 			actions: {
 				action1: new Action({
@@ -755,6 +755,11 @@ describe('actions', () => {
 				}),
 				action2,
 			},
+			entry: [
+				{
+					actions: ['action1'],
+				},
+			],
 		});
 		state.start();
 	});

--- a/packages/hine/tests/atomic/conditions.test.js
+++ b/packages/hine/tests/atomic/conditions.test.js
@@ -6,18 +6,13 @@ describe('conditions', () => {
 		const cond2 = new Condition({
 			run: () => false,
 		});
-		new AtomicState({
+		const state = new AtomicState({
 			entry: [
 				{
 					condition: 'cond1',
 					actions: ['do'],
 				},
 			],
-			actions: {
-				do: new Action({
-					run() {},
-				}),
-			},
 			conditions: {
 				cond1: new Condition({
 					run({ ownerState }) {
@@ -29,7 +24,15 @@ describe('conditions', () => {
 				}),
 				cond2,
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				do: new Action({
+					run() {},
+				}),
+			},
+		});
+		state.start();
 	});
 	it('calls condition in machine context', () => {
 		const condition = new Condition({
@@ -43,17 +46,19 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			actions: {
-				action: new Action({
-					run() {},
-				}),
-			},
 			entry: [
 				{
 					condition: 'condition',
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					run() {},
+				}),
+			},
 		});
 		state.start();
 	});
@@ -70,9 +75,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -80,6 +82,11 @@ describe('conditions', () => {
 						actions: ['action'],
 					},
 				],
+			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		state.start();
@@ -105,9 +112,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -116,7 +120,13 @@ describe('conditions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -141,9 +151,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -152,7 +159,13 @@ describe('conditions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -181,9 +194,6 @@ describe('conditions', () => {
 									},
 								}),
 							},
-							actions: {
-								action: new Action({ run() {} }),
-							},
 							on: {
 								event: [
 									{
@@ -196,7 +206,21 @@ describe('conditions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					states: {
+						s11: {
+							actions: {
+								action: new Action({ run() {} }),
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
 		state.subscribe(() => {
 			log.push('sub');
 		});
@@ -224,9 +248,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -235,7 +256,13 @@ describe('conditions', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -251,9 +278,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -261,6 +285,11 @@ describe('conditions', () => {
 						actions: ['action'],
 					},
 				],
+			},
+		});
+		state1.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		expect(() => state1.start()).toThrow(/unknown condition/);
@@ -273,9 +302,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -283,6 +309,11 @@ describe('conditions', () => {
 						actions: ['action'],
 					},
 				],
+			},
+		});
+		state2.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		expect(() => state2.start()).not.toThrow();
@@ -299,15 +330,17 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			entry: [
 				{
 					condition: 'condition',
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
 		});
 		expect(state.condition).toBe(null);
 		state.start();

--- a/packages/hine/tests/atomic/conditions.test.js
+++ b/packages/hine/tests/atomic/conditions.test.js
@@ -7,12 +7,6 @@ describe('conditions', () => {
 			run: () => false,
 		});
 		const state = new AtomicState({
-			entry: [
-				{
-					condition: 'cond1',
-					actions: ['do'],
-				},
-			],
 			conditions: {
 				cond1: new Condition({
 					run({ ownerState }) {
@@ -31,6 +25,12 @@ describe('conditions', () => {
 					run() {},
 				}),
 			},
+			entry: [
+				{
+					condition: 'cond1',
+					actions: ['do'],
+				},
+			],
 		});
 		state.start();
 	});
@@ -46,12 +46,6 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			entry: [
-				{
-					condition: 'condition',
-					actions: ['action'],
-				},
-			],
 		});
 		state.monitor({
 			actions: {
@@ -59,6 +53,12 @@ describe('conditions', () => {
 					run() {},
 				}),
 			},
+			entry: [
+				{
+					condition: 'condition',
+					actions: ['action'],
+				},
+			],
 		});
 		state.start();
 	});
@@ -330,17 +330,17 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
 			entry: [
 				{
 					condition: 'condition',
 					actions: ['action'],
 				},
 			],
-		});
-		state.monitor({
-			actions: {
-				action: new Action({ run() {} }),
-			},
 		});
 		expect(state.condition).toBe(null);
 		state.start();

--- a/packages/hine/tests/atomic/dispatch.test.js
+++ b/packages/hine/tests/atomic/dispatch.test.js
@@ -28,7 +28,9 @@ describe('dispatch', () => {
 		});
 		const compound = new CompoundState({
 			states: { s1, s2 },
-		}).start();
+		});
+		compound.monitor({});
+		compound.start();
 		compound.dispatch('event');
 		expect(compound.state).toBe(s2);
 		compound.dispatch('event');

--- a/packages/hine/tests/atomic/matches.test.js
+++ b/packages/hine/tests/atomic/matches.test.js
@@ -9,10 +9,11 @@ describe('matches', () => {
 		expect(machine.matches('machine')).toBe(false);
 	});
 	it('matches state name when started', () => {
-		const machine = new AtomicState({
+		const state = new AtomicState({
 			name: 'machine',
-		}).start();
-		expect(machine.matches('machine')).toBe(true);
+		});
+		state.start();
+		expect(state.matches('machine')).toBe(true);
 	});
 	it('matches anonymous states', () => {
 		const machine = new AtomicState().start();
@@ -26,12 +27,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({
-					notifyBefore: true,
-					run() {},
-				}),
-			},
 		});
 		let count = 1;
 		state.subscribe(() => {
@@ -41,6 +36,14 @@ describe('matches', () => {
 				expect(state.matches('state.(action)')).toBe(true);
 			}
 			count += 1;
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: true,
+					run() {},
+				}),
+			},
 		});
 		state.start();
 	});
@@ -53,9 +56,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({
 					notifyBefore: true,
@@ -72,6 +72,11 @@ describe('matches', () => {
 			}
 			count += 1;
 		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
 		state.start();
 	});
 	it('matches handler', () => {
@@ -82,12 +87,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({
-					notifyBefore: true,
-					run() {},
-				}),
-			},
 		});
 		let count = 1;
 		state.subscribe(() => {
@@ -99,6 +98,14 @@ describe('matches', () => {
 				expect(state.matches('state.[0]')).toBe(true);
 			}
 			count += 1;
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: true,
+					run() {},
+				}),
+			},
 		});
 		state.start();
 	});

--- a/packages/hine/tests/atomic/start.test.js
+++ b/packages/hine/tests/atomic/start.test.js
@@ -5,12 +5,14 @@ describe('start', () => {
 	it('is resolves config idempotently', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new AtomicState({
+		const state = new AtomicState({
 			always: [
 				{
 					actions: ['always'],
 				},
 			],
+		});
+		state.monitor({
 			actions: {
 				always: new Action({
 					run() {
@@ -18,9 +20,10 @@ describe('start', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.start();
 		expect(log).toEqual(['always']);
-		machine.start();
+		state.start();
 		expect(log).toEqual(['always', 'always']);
 	});
 	it('emits start event', () => {

--- a/packages/hine/tests/atomic/step.test.js
+++ b/packages/hine/tests/atomic/step.test.js
@@ -13,11 +13,6 @@ describe('step', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({
-					run() {},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -25,7 +20,15 @@ describe('step', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					run() {},
+				}),
+			},
+		});
+		state.start();
 
 		let count = 0;
 		state.subscribe(() => count++);
@@ -55,7 +58,6 @@ describe('step', () => {
 					actions: ['action'],
 				},
 			],
-			actions: { action },
 			conditions: { condition },
 			on: {
 				event: [
@@ -65,7 +67,9 @@ describe('step', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({ actions: { action }});
+		state.start();
 
 		const expected = [Handler, condition, action, Handler, action];
 		const expectedIterator = expected[Symbol.iterator]();
@@ -90,6 +94,8 @@ describe('step', () => {
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					run() {},
@@ -106,12 +112,15 @@ describe('step', () => {
 					actions: ['action'],
 				},
 			],
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					run() {},
 				}),
 			},
-		}).start();
+		});
+		state.start();
 		state.step('event').next();
 		expect(() => state.step('event').next()).toThrow(/in progress/);
 	});

--- a/packages/hine/tests/atomic/subscribe.test.js
+++ b/packages/hine/tests/atomic/subscribe.test.js
@@ -3,11 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('subscribe', () => {
 	it('calls subscribers on start', () => {
-		const machine = new AtomicState({
-			actions: {},
-			always: [],
-			entry: [],
-		});
+		const machine = new AtomicState();
 		let count = 0;
 		machine.subscribe(() => count++);
 		expect(count).toBe(1);
@@ -16,12 +12,7 @@ describe('subscribe', () => {
 		expect(count).toBe(2);
 	});
 	it('calls subscribers on disptach', () => {
-		const machine = new AtomicState({
-			actions: {
-				noop: new Action({
-					run() {},
-				}),
-			},
+		const state = new AtomicState({
 			on: {
 				event: [
 					{
@@ -29,15 +20,23 @@ describe('subscribe', () => {
 					},
 				],
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				noop: new Action({
+					run() {},
+				}),
+			},
+		});
+		state.start();
 		let count = 0;
-		machine.subscribe(() => count++);
+		state.subscribe(() => count++);
 		expect(count).toBe(1);
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(count).toBe(2);
 
-		machine.dispatch('useless');
+		state.dispatch('useless');
 		expect(count).toBe(3);
 	});
 });

--- a/packages/hine/tests/compound/actions.test.js
+++ b/packages/hine/tests/compound/actions.test.js
@@ -7,20 +7,8 @@ describe('actions', () => {
 	it('runs initial entry then transient actions', () => {
 		/** @type {string[]} */
 		const log = [];
-		new CompoundState({
+		const state = new CompoundState({
 			name: 's0',
-			actions: {
-				always0: new Action({
-					run() {
-						log.push('always0');
-					},
-				}),
-				entry0: new Action({
-					run() {
-						log.push('entry0');
-					},
-				}),
-			},
 			always: [
 				{
 					actions: ['always0'],
@@ -33,18 +21,6 @@ describe('actions', () => {
 			],
 			states: {
 				s1: new CompoundState({
-					actions: {
-						always1: new Action({
-							run() {
-								log.push('always1');
-							},
-						}),
-						entry1: new Action({
-							run() {
-								log.push('entry1');
-							},
-						}),
-					},
 					always: [
 						{
 							actions: ['always1'],
@@ -57,18 +33,6 @@ describe('actions', () => {
 					],
 					states: {
 						s2: new AtomicState({
-							actions: {
-								always2: new Action({
-									run() {
-										log.push('always2');
-									},
-								}),
-								entry2: new Action({
-									run() {
-										log.push('entry2');
-									},
-								}),
-							},
 							always: [
 								{
 									actions: ['always2'],
@@ -83,14 +47,61 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				always0: new Action({
+					run() {
+						log.push('always0');
+					},
+				}),
+				entry0: new Action({
+					run() {
+						log.push('entry0');
+					},
+				}),
+			},
+			states: {
+				s1: {
+					actions: {
+						always1: new Action({
+							run() {
+								log.push('always1');
+							},
+						}),
+						entry1: new Action({
+							run() {
+								log.push('entry1');
+							},
+						}),
+					},
+					states: {
+						s2: {
+							actions: {
+								always2: new Action({
+									run() {
+										log.push('always2');
+									},
+								}),
+								entry2: new Action({
+									run() {
+										log.push('entry2');
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
 		expect(log).toEqual(['entry0', 'entry1', 'entry2', 'always0', 'always1', 'always2']);
 	});
 
 	it('runs entry then always actions on transition', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				a: new AtomicState({
 					on: {
@@ -102,18 +113,6 @@ describe('actions', () => {
 					},
 				}),
 				b: new CompoundState({
-					actions: {
-						always0: new Action({
-							run() {
-								log.push('always0');
-							},
-						}),
-						entry0: new Action({
-							run() {
-								log.push('entry0');
-							},
-						}),
-					},
 					always: [
 						{
 							actions: ['always0'],
@@ -126,18 +125,6 @@ describe('actions', () => {
 					],
 					states: {
 						s1: new CompoundState({
-							actions: {
-								always1: new Action({
-									run() {
-										log.push('always1');
-									},
-								}),
-								entry1: new Action({
-									run() {
-										log.push('entry1');
-									},
-								}),
-							},
 							always: [
 								{
 									actions: ['always1'],
@@ -150,18 +137,6 @@ describe('actions', () => {
 							],
 							states: {
 								s2: new AtomicState({
-									actions: {
-										always2: new Action({
-											run() {
-												log.push('always2');
-											},
-										}),
-										entry2: new Action({
-											run() {
-												log.push('entry2');
-											},
-										}),
-									},
 									always: [
 										{
 											actions: ['always2'],
@@ -178,22 +153,66 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
-		machine.dispatch('event');
+		});
+		state.monitor({
+			states: {
+				b: {
+					actions: {
+						always0: new Action({
+							run() {
+								log.push('always0');
+							},
+						}),
+						entry0: new Action({
+							run() {
+								log.push('entry0');
+							},
+						}),
+					},
+					states: {
+						s1: {
+							actions: {
+								always1: new Action({
+									run() {
+										log.push('always1');
+									},
+								}),
+								entry1: new Action({
+									run() {
+										log.push('entry1');
+									},
+								}),
+							},
+							states: {
+								s2: {
+									actions: {
+										always2: new Action({
+											run() {
+												log.push('always2');
+											},
+										}),
+										entry2: new Action({
+											run() {
+												log.push('entry2');
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
+		state.dispatch('event');
 		expect(log).toEqual(['entry0', 'entry1', 'entry2', 'always0', 'always1', 'always2']);
 	});
 
 	it('runs exit actions with leaves first and root last', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
-			actions: {
-				exit0: new Action({
-					run() {
-						log.push('exit0');
-					},
-				}),
-			},
+		const state = new CompoundState({
 			exit: [
 				{
 					actions: ['exit0'],
@@ -201,13 +220,6 @@ describe('actions', () => {
 			],
 			states: {
 				s1: new CompoundState({
-					actions: {
-						exit1: new Action({
-							run() {
-								log.push('exit1');
-							},
-						}),
-					},
 					exit: [
 						{
 							actions: ['exit1'],
@@ -222,13 +234,6 @@ describe('actions', () => {
 					},
 					states: {
 						s11: new CompoundState({
-							actions: {
-								exit11: new Action({
-									run() {
-										log.push('exit11');
-									},
-								}),
-							},
 							exit: [
 								{
 									actions: ['exit11'],
@@ -236,13 +241,6 @@ describe('actions', () => {
 							],
 							states: {
 								s111: new AtomicState({
-									actions: {
-										exit111: new Action({
-											run() {
-												log.push('exit111');
-											},
-										}),
-									},
 									exit: [
 										{
 											actions: ['exit111'],
@@ -255,24 +253,60 @@ describe('actions', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				exit0: new Action({
+					run() {
+						log.push('exit0');
+					},
+				}),
+			},
+			states: {
+				s1: {
+					actions: {
+						exit1: new Action({
+							run() {
+								log.push('exit1');
+							},
+						}),
+					},
+					states: {
+						s11: {
+							actions: {
+								exit11: new Action({
+									run() {
+										log.push('exit11');
+									},
+								}),
+							},
+							states: {
+								s111: {
+									actions: {
+										exit111: new Action({
+											run() {
+												log.push('exit111');
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
 		log.length = 0;
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['exit111', 'exit11', 'exit1']);
 	});
 
 	it('runs on actions with leaves first and root last', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
-			actions: {
-				on0: new Action({
-					run() {
-						log.push('on0');
-					},
-				}),
-			},
+		const state = new CompoundState({
 			on: {
 				event: [
 					{
@@ -282,13 +316,6 @@ describe('actions', () => {
 			},
 			states: {
 				s1: new CompoundState({
-					actions: {
-						on1: new Action({
-							run() {
-								log.push('on1');
-							},
-						}),
-					},
 					on: {
 						event: [
 							{
@@ -298,13 +325,6 @@ describe('actions', () => {
 					},
 					states: {
 						s11: new CompoundState({
-							actions: {
-								on11: new Action({
-									run() {
-										log.push('on11');
-									},
-								}),
-							},
 							on: {
 								event: [
 									{
@@ -314,13 +334,6 @@ describe('actions', () => {
 							},
 							states: {
 								s111: new AtomicState({
-									actions: {
-										on111: new Action({
-											run() {
-												log.push('on111');
-											},
-										}),
-									},
 									on: {
 										event: [
 											{
@@ -335,29 +348,60 @@ describe('actions', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
-		log.length = 0;
-
-		machine.dispatch('event');
-		expect(log).toEqual(['on111', 'on11', 'on1', 'on0']);
-	});
-
-	it('interleaves on actions with always actions', () => {
-		/** @type {string[]} */
-		const log = [];
-		const machine = new CompoundState({
+		});
+		state.monitor({
 			actions: {
-				always0: new Action({
-					run() {
-						log.push('always0');
-					},
-				}),
 				on0: new Action({
 					run() {
 						log.push('on0');
 					},
 				}),
 			},
+			states: {
+				s1: {
+					actions: {
+						on1: new Action({
+							run() {
+								log.push('on1');
+							},
+						}),
+					},
+					states: {
+						s11: {
+							actions: {
+								on11: new Action({
+									run() {
+										log.push('on11');
+									},
+								}),
+							},
+							states: {
+								s111: {
+									actions: {
+										on111: new Action({
+											run() {
+												log.push('on111');
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
+		log.length = 0;
+
+		state.dispatch('event');
+		expect(log).toEqual(['on111', 'on11', 'on1', 'on0']);
+	});
+
+	it('interleaves on actions with always actions', () => {
+		/** @type {string[]} */
+		const log = [];
+		const state = new CompoundState({
 			always: [
 				{
 					actions: ['always0'],
@@ -372,18 +416,6 @@ describe('actions', () => {
 			},
 			states: {
 				s1: new CompoundState({
-					actions: {
-						always1: new Action({
-							run() {
-								log.push('always1');
-							},
-						}),
-						on1: new Action({
-							run() {
-								log.push('on1');
-							},
-						}),
-					},
 					always: [
 						{
 							actions: ['always1'],
@@ -398,18 +430,6 @@ describe('actions', () => {
 					},
 					states: {
 						s11: new CompoundState({
-							actions: {
-								always11: new Action({
-									run() {
-										log.push('always11');
-									},
-								}),
-								on11: new Action({
-									run() {
-										log.push('on11');
-									},
-								}),
-							},
 							always: [
 								{
 									actions: ['always11'],
@@ -424,18 +444,6 @@ describe('actions', () => {
 							},
 							states: {
 								s111: new AtomicState({
-									actions: {
-										always111: new Action({
-											run() {
-												log.push('always111');
-											},
-										}),
-										on111: new Action({
-											run() {
-												log.push('on111');
-											},
-										}),
-									},
 									always: [
 										{
 											actions: ['always111'],
@@ -455,10 +463,73 @@ describe('actions', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				always0: new Action({
+					run() {
+						log.push('always0');
+					},
+				}),
+				on0: new Action({
+					run() {
+						log.push('on0');
+					},
+				}),
+			},
+			states: {
+				s1: {
+					actions: {
+						always1: new Action({
+							run() {
+								log.push('always1');
+							},
+						}),
+						on1: new Action({
+							run() {
+								log.push('on1');
+							},
+						}),
+					},
+					states: {
+						s11: {
+							actions: {
+								always11: new Action({
+									run() {
+										log.push('always11');
+									},
+								}),
+								on11: new Action({
+									run() {
+										log.push('on11');
+									},
+								}),
+							},
+							states: {
+								s111: {
+									actions: {
+										always111: new Action({
+											run() {
+												log.push('always111');
+											},
+										}),
+										on111: new Action({
+											run() {
+												log.push('on111');
+											},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+		state.start();
 		log.length = 0;
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual([
 			'on111',
 			'always111',
@@ -474,7 +545,82 @@ describe('actions', () => {
 	it('runs exit, transition, entry then always actions', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
+			always: [
+				{
+					actions: ['always0'],
+				},
+			],
+			entry: [
+				{
+					actions: ['entry0'],
+				},
+			],
+			exit: [
+				{
+					actions: ['exit0'],
+				},
+			],
+			states: {
+				s1: new CompoundState({
+					exit: [
+						{
+							actions: ['exit1'],
+						},
+					],
+					on: {
+						event: [
+							{
+								transitionTo: 's2',
+								actions: ['on1'],
+							},
+						],
+					},
+					states: {
+						s11: new CompoundState({
+							exit: [
+								{
+									actions: ['exit11'],
+								},
+							],
+							states: {
+								s111: new AtomicState(),
+							},
+						}),
+					},
+				}),
+				s2: new CompoundState({
+					always: [
+						{
+							actions: ['always2'],
+						},
+					],
+					entry: [
+						{
+							actions: ['entry2'],
+						},
+					],
+					states: {
+						s21: new CompoundState({
+							always: [
+								{
+									actions: ['always21'],
+								},
+							],
+							entry: [
+								{
+									actions: ['entry21'],
+								},
+							],
+							states: {
+								s211: new AtomicState(),
+							},
+						}),
+					},
+				}),
+			},
+		});
+		state.monitor({
 			actions: {
 				always0: new Action({
 					run() {
@@ -497,23 +643,8 @@ describe('actions', () => {
 					},
 				}),
 			},
-			always: [
-				{
-					actions: ['always0'],
-				},
-			],
-			entry: [
-				{
-					actions: ['entry0'],
-				},
-			],
-			exit: [
-				{
-					actions: ['exit0'],
-				},
-			],
 			states: {
-				s1: new CompoundState({
+				s1: {
 					actions: {
 						exit1: new Action({
 							run() {
@@ -526,21 +657,8 @@ describe('actions', () => {
 							},
 						}),
 					},
-					exit: [
-						{
-							actions: ['exit1'],
-						},
-					],
-					on: {
-						event: [
-							{
-								transitionTo: 's2',
-								actions: ['on1'],
-							},
-						],
-					},
 					states: {
-						s11: new CompoundState({
+						s11: {
 							actions: {
 								exit11: new Action({
 									run() {
@@ -553,18 +671,10 @@ describe('actions', () => {
 									},
 								}),
 							},
-							exit: [
-								{
-									actions: ['exit11'],
-								},
-							],
-							states: {
-								s111: new AtomicState(),
-							},
-						}),
+						},
 					},
-				}),
-				s2: new CompoundState({
+				},
+				s2: {
 					actions: {
 						always2: new Action({
 							run() {
@@ -582,18 +692,8 @@ describe('actions', () => {
 							},
 						}),
 					},
-					always: [
-						{
-							actions: ['always2'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry2'],
-						},
-					],
 					states: {
-						s21: new CompoundState({
+						s21: {
 							actions: {
 								always21: new Action({
 									run() {
@@ -611,27 +711,15 @@ describe('actions', () => {
 									},
 								}),
 							},
-							always: [
-								{
-									actions: ['always21'],
-								},
-							],
-							entry: [
-								{
-									actions: ['entry21'],
-								},
-							],
-							states: {
-								s211: new AtomicState(),
-							},
-						}),
+						},
 					},
-				}),
+				},
 			},
-		}).start();
+		});
+		state.start();
 		log.length = 0;
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual([
 			'exit11',
 			'exit1',
@@ -646,7 +734,7 @@ describe('actions', () => {
 
 	it('runs always actions on unhandled events', () => {
 		let alwaysCount = 0;
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				current: new CompoundState({
 					always: [
@@ -654,6 +742,15 @@ describe('actions', () => {
 							actions: ['always'],
 						},
 					],
+					states: {
+						s: new AtomicState(),
+					},
+				}),
+			},
+		});
+		state.monitor({
+			states: {
+				current: {
 					actions: {
 						always: new Action({
 							run() {
@@ -661,45 +758,21 @@ describe('actions', () => {
 							},
 						}),
 					},
-					states: {
-						s: new AtomicState(),
-					},
-				}),
-			},
-		}).start();
+				}
+			}
+		});
+		state.start();
 		expect(alwaysCount).toBe(1);
 
-		machine.dispatch('non-existent');
+		state.dispatch('non-existent');
 		expect(alwaysCount).toBe(2);
 	});
 
 	it('runs actions on parents', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 's0',
-			actions: {
-				always: new Action({
-					run() {
-						log.push('always');
-					},
-				}),
-				entry: new Action({
-					run() {
-						log.push('entry');
-					},
-				}),
-				exit: new Action({
-					run() {
-						log.push('exit');
-					},
-				}),
-				on: new Action({
-					run() {
-						log.push('on');
-					},
-				}),
-			},
 			states: {
 				s1: new CompoundState({
 					always: [
@@ -735,17 +808,79 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				always: new Action({
+					run() {
+						log.push('always');
+					},
+				}),
+				entry: new Action({
+					run() {
+						log.push('entry');
+					},
+				}),
+				exit: new Action({
+					run() {
+						log.push('exit');
+					},
+				}),
+				on: new Action({
+					run() {
+						log.push('on');
+					},
+				}),
+			},
+		});
+		state.start();
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['entry', 'always', 'exit', 'on']);
 	});
 
 	it('does not run parent actions if own action matches', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 's0',
+			states: {
+				s1: new CompoundState({
+					always: [
+						{
+							actions: ['always'],
+						},
+					],
+					entry: [
+						{
+							actions: ['entry'],
+						},
+					],
+					exit: [
+						{
+							actions: ['exit'],
+						},
+					],
+					on: {
+						event: [
+							{
+								transitionTo: 's2',
+								actions: ['on'],
+							},
+						],
+					},
+					states: {
+						s11: new AtomicState(),
+					},
+				}),
+				s2: new CompoundState({
+					states: {
+						s21: new AtomicState(),
+					},
+				}),
+			},
+		});
+		state.monitor({
 			actions: {
 				always: new Action({
 					run() {
@@ -769,7 +904,7 @@ describe('actions', () => {
 				}),
 			},
 			states: {
-				s1: new CompoundState({
+				s1: {
 					actions: {
 						always: new Action({
 							run() {
@@ -792,62 +927,20 @@ describe('actions', () => {
 							},
 						}),
 					},
-					always: [
-						{
-							actions: ['always'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry'],
-						},
-					],
-					exit: [
-						{
-							actions: ['exit'],
-						},
-					],
-					on: {
-						event: [
-							{
-								transitionTo: 's2',
-								actions: ['on'],
-							},
-						],
-					},
-					states: {
-						s11: new AtomicState(),
-					},
-				}),
-				s2: new CompoundState({
-					states: {
-						s21: new AtomicState(),
-					},
-				}),
+				},
 			},
-		}).start();
+		});
+		state.start();
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(log).toEqual(['entry', 'always', 'exit', 'on']);
 	});
 	it('runs transitions in always handlers', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new CompoundState({
-					actions: {
-						entry1: new Action({
-							run() {
-								log.push('entry1');
-							},
-						}),
-						transition1: new Action({
-							run() {
-								log.push('transition1');
-							},
-						}),
-					},
 					entry: [
 						{
 							actions: ['entry1'],
@@ -866,13 +959,6 @@ describe('actions', () => {
 					},
 				}),
 				s2: new CompoundState({
-					actions: {
-						always2: new Action({
-							run() {
-								log.push('always2');
-							},
-						}),
-					},
 					always: [
 						{
 							transitionTo: 's1',
@@ -884,10 +970,38 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					actions: {
+						entry1: new Action({
+							run() {
+								log.push('entry1');
+							},
+						}),
+						transition1: new Action({
+							run() {
+								log.push('transition1');
+							},
+						}),
+					},
+				},
+				s2: {
+					actions: {
+						always2: new Action({
+							run() {
+								log.push('always2');
+							},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
 
-		machine.dispatch('event');
-		expect(machine.state?.name).toEqual('s1');
+		state.dispatch('event');
+		expect(state.state?.name).toEqual('s1');
 		expect(log).toEqual(['entry1', 'transition1', 'always2', 'entry1']);
 	});
 	it('calls actions with self reference', () => {
@@ -898,9 +1012,6 @@ describe('actions', () => {
 			},
 		});
 		const state = new CompoundState({
-			actions: {
-				action,
-			},
 			entry: [
 				{
 					actions: ['action'],
@@ -910,20 +1021,17 @@ describe('actions', () => {
 				s1: new AtomicState(),
 			},
 		});
+		state.monitor({
+			actions: {
+				action,
+			},
+		});
 		state.start();
 	});
 	it('calls subscribers before action', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new CompoundState({
-			actions: {
-				action: new Action({
-					notifyBefore: true,
-					run() {
-						log.push('action');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -933,6 +1041,16 @@ describe('actions', () => {
 			},
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: true,
+					run() {
+						log.push('action');
+					},
+				}),
 			},
 		});
 		state.start();
@@ -949,14 +1067,6 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new CompoundState({
-			actions: {
-				action: new Action({
-					notifyAfter: true,
-					run() {
-						log.push('action');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -967,7 +1077,18 @@ describe('actions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyAfter: true,
+					run() {
+						log.push('action');
+					},
+				}),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -984,13 +1105,6 @@ describe('actions', () => {
 			actionConfig: {
 				notifyBefore: true,
 			},
-			actions: {
-				action: new Action({
-					run() {
-						log.push('action');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -1001,7 +1115,17 @@ describe('actions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					run() {
+						log.push('action');
+					},
+				}),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -1018,14 +1142,6 @@ describe('actions', () => {
 			actionConfig: {
 				notifyBefore: true,
 			},
-			actions: {
-				action: new Action({
-					notifyBefore: false,
-					run() {
-						log.push('action');
-					},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -1036,7 +1152,18 @@ describe('actions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: false,
+					run() {
+						log.push('action');
+					},
+				}),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -1051,14 +1178,6 @@ describe('actions', () => {
 			},
 			states: {
 				s1: new CompoundState({
-					actions: {
-						action: new Action({
-							run() {
-								log.push('action');
-								return true;
-							},
-						}),
-					},
 					on: {
 						event: [
 							{
@@ -1071,7 +1190,22 @@ describe('actions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					actions: {
+						action: new Action({
+							run() {
+								log.push('action');
+								return true;
+							},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -1083,12 +1217,6 @@ describe('actions', () => {
 	});
 	it('resolves action using most specific configured name', () => {
 		const state = new CompoundState({
-			actions: {
-				action: new Action({
-					name: 'other-action',
-					run() {},
-				}),
-			},
 			on: {
 				event: [
 					{
@@ -1100,14 +1228,16 @@ describe('actions', () => {
 				s1: new AtomicState(),
 			},
 		});
-		expect(() => state.start()).toThrow(/unknown action/);
-		const state2 = new CompoundState({
+		state.monitor({
 			actions: {
 				action: new Action({
 					name: 'other-action',
 					run() {},
 				}),
 			},
+		});
+		expect(() => state.start()).toThrow(/unknown action/);
+		const state2 = new CompoundState({
 			on: {
 				event: [
 					{
@@ -1117,6 +1247,14 @@ describe('actions', () => {
 			},
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state2.monitor({
+			actions: {
+				action: new Action({
+					name: 'other-action',
+					run() {},
+				}),
 			},
 		});
 		expect(() => state2.start()).not.toThrow();
@@ -1129,9 +1267,6 @@ describe('actions', () => {
 			},
 		});
 		const state = new CompoundState({
-			actions: {
-				action,
-			},
 			entry: [
 				{
 					actions: ['action'],
@@ -1139,6 +1274,11 @@ describe('actions', () => {
 			],
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
+			actions: {
+				action,
 			},
 		});
 		expect(state.action).toBe(null);
@@ -1149,12 +1289,17 @@ describe('actions', () => {
 		const action2 = new Action({
 			run: () => 'test',
 		});
-		new CompoundState({
+		const state = new CompoundState({
 			entry: [
 				{
 					actions: ['action1'],
 				},
 			],
+			states: {
+				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
 			actions: {
 				action1: new Action({
 					run({ ownerState }) {
@@ -1166,16 +1311,19 @@ describe('actions', () => {
 				}),
 				action2,
 			},
-			states: {
-				s1: new AtomicState(),
-			},
-		}).start();
+		});
+		state.start();
 	});
 	it('calls actions with value', () => {
 		const state = new CompoundState({
 			on: {
 				event: [{ actions: ['action']}],
 			},
+			states: {
+				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
 			actions: {
 				action: new Action({
 					run({ value }) {
@@ -1183,10 +1331,8 @@ describe('actions', () => {
 					},
 				}),
 			},
-			states: {
-				s1: new AtomicState(),
-			},
-		}).start();
+		});
+		state.start();
 
 		state.dispatch('event', 'my-value');
 	});

--- a/packages/hine/tests/compound/actions.test.js
+++ b/packages/hine/tests/compound/actions.test.js
@@ -14,11 +14,6 @@ describe('actions', () => {
 					actions: ['always0'],
 				},
 			],
-			entry: [
-				{
-					actions: ['entry0'],
-				},
-			],
 			states: {
 				s1: new CompoundState({
 					always: [
@@ -26,21 +21,11 @@ describe('actions', () => {
 							actions: ['always1'],
 						},
 					],
-					entry: [
-						{
-							actions: ['entry1'],
-						},
-					],
 					states: {
 						s2: new AtomicState({
 							always: [
 								{
 									actions: ['always2'],
-								},
-							],
-							entry: [
-								{
-									actions: ['entry2'],
 								},
 							],
 						}),
@@ -61,6 +46,11 @@ describe('actions', () => {
 					},
 				}),
 			},
+			entry: [
+				{
+					actions: ['entry0'],
+				},
+			],
 			states: {
 				s1: {
 					actions: {
@@ -75,6 +65,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry1'],
+						},
+					],
 					states: {
 						s2: {
 							actions: {
@@ -89,6 +84,11 @@ describe('actions', () => {
 									},
 								}),
 							},
+							entry: [
+								{
+									actions: ['entry2'],
+								},
+							],
 						},
 					},
 				},
@@ -118,11 +118,6 @@ describe('actions', () => {
 							actions: ['always0'],
 						},
 					],
-					entry: [
-						{
-							actions: ['entry0'],
-						},
-					],
 					states: {
 						s1: new CompoundState({
 							always: [
@@ -130,21 +125,11 @@ describe('actions', () => {
 									actions: ['always1'],
 								},
 							],
-							entry: [
-								{
-									actions: ['entry1'],
-								},
-							],
 							states: {
 								s2: new AtomicState({
 									always: [
 										{
 											actions: ['always2'],
-										},
-									],
-									entry: [
-										{
-											actions: ['entry2'],
 										},
 									],
 								}),
@@ -169,6 +154,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry0'],
+						},
+					],
 					states: {
 						s1: {
 							actions: {
@@ -183,6 +173,11 @@ describe('actions', () => {
 									},
 								}),
 							},
+							entry: [
+								{
+									actions: ['entry1'],
+								},
+							],
 							states: {
 								s2: {
 									actions: {
@@ -197,6 +192,11 @@ describe('actions', () => {
 											},
 										}),
 									},
+									entry: [
+										{
+											actions: ['entry2'],
+										},
+									],
 								},
 							},
 						},
@@ -213,18 +213,8 @@ describe('actions', () => {
 		/** @type {string[]} */
 		const log = [];
 		const state = new CompoundState({
-			exit: [
-				{
-					actions: ['exit0'],
-				},
-			],
 			states: {
 				s1: new CompoundState({
-					exit: [
-						{
-							actions: ['exit1'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -234,19 +224,8 @@ describe('actions', () => {
 					},
 					states: {
 						s11: new CompoundState({
-							exit: [
-								{
-									actions: ['exit11'],
-								},
-							],
 							states: {
-								s111: new AtomicState({
-									exit: [
-										{
-											actions: ['exit111'],
-										},
-									],
-								}),
+								s111: new AtomicState(),
 							},
 						}),
 					},
@@ -262,6 +241,11 @@ describe('actions', () => {
 					},
 				}),
 			},
+			exit: [
+				{
+					actions: ['exit0'],
+				},
+			],
 			states: {
 				s1: {
 					actions: {
@@ -271,6 +255,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					exit: [
+						{
+							actions: ['exit1'],
+						},
+					],
 					states: {
 						s11: {
 							actions: {
@@ -280,6 +269,11 @@ describe('actions', () => {
 									},
 								}),
 							},
+							exit: [
+								{
+									actions: ['exit11'],
+								},
+							],
 							states: {
 								s111: {
 									actions: {
@@ -289,6 +283,11 @@ describe('actions', () => {
 											},
 										}),
 									},
+									exit: [
+										{
+											actions: ['exit111'],
+										},
+									],
 								},
 							},
 						},
@@ -551,23 +550,8 @@ describe('actions', () => {
 					actions: ['always0'],
 				},
 			],
-			entry: [
-				{
-					actions: ['entry0'],
-				},
-			],
-			exit: [
-				{
-					actions: ['exit0'],
-				},
-			],
 			states: {
 				s1: new CompoundState({
-					exit: [
-						{
-							actions: ['exit1'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -578,11 +562,6 @@ describe('actions', () => {
 					},
 					states: {
 						s11: new CompoundState({
-							exit: [
-								{
-									actions: ['exit11'],
-								},
-							],
 							states: {
 								s111: new AtomicState(),
 							},
@@ -595,21 +574,11 @@ describe('actions', () => {
 							actions: ['always2'],
 						},
 					],
-					entry: [
-						{
-							actions: ['entry2'],
-						},
-					],
 					states: {
 						s21: new CompoundState({
 							always: [
 								{
 									actions: ['always21'],
-								},
-							],
-							entry: [
-								{
-									actions: ['entry21'],
 								},
 							],
 							states: {
@@ -643,6 +612,16 @@ describe('actions', () => {
 					},
 				}),
 			},
+			entry: [
+				{
+					actions: ['entry0'],
+				},
+			],
+			exit: [
+				{
+					actions: ['exit0'],
+				},
+			],
 			states: {
 				s1: {
 					actions: {
@@ -657,6 +636,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					exit: [
+						{
+							actions: ['exit1'],
+						},
+					],
 					states: {
 						s11: {
 							actions: {
@@ -671,6 +655,11 @@ describe('actions', () => {
 									},
 								}),
 							},
+							exit: [
+								{
+									actions: ['exit11'],
+								},
+							],
 						},
 					},
 				},
@@ -692,6 +681,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry2'],
+						},
+					],
 					states: {
 						s21: {
 							actions: {
@@ -711,6 +705,11 @@ describe('actions', () => {
 									},
 								}),
 							},
+							entry: [
+								{
+									actions: ['entry21'],
+								},
+							],
 						},
 					},
 				},
@@ -780,16 +779,6 @@ describe('actions', () => {
 							actions: ['always'],
 						},
 					],
-					entry: [
-						{
-							actions: ['entry'],
-						},
-					],
-					exit: [
-						{
-							actions: ['exit'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -832,6 +821,20 @@ describe('actions', () => {
 					},
 				}),
 			},
+			states: {
+				s1: {
+					entry: [
+						{
+							actions: ['entry'],
+						},
+					],
+					exit: [
+						{
+							actions: ['exit'],
+						},
+					],
+				},
+			},
 		});
 		state.start();
 
@@ -849,16 +852,6 @@ describe('actions', () => {
 					always: [
 						{
 							actions: ['always'],
-						},
-					],
-					entry: [
-						{
-							actions: ['entry'],
-						},
-					],
-					exit: [
-						{
-							actions: ['exit'],
 						},
 					],
 					on: {
@@ -927,6 +920,16 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry'],
+						},
+					],
+					exit: [
+						{
+							actions: ['exit'],
+						},
+					],
 				},
 			},
 		});
@@ -941,11 +944,6 @@ describe('actions', () => {
 		const state = new CompoundState({
 			states: {
 				s1: new CompoundState({
-					entry: [
-						{
-							actions: ['entry1'],
-						},
-					],
 					on: {
 						event: [
 							{
@@ -986,6 +984,11 @@ describe('actions', () => {
 							},
 						}),
 					},
+					entry: [
+						{
+							actions: ['entry1'],
+						},
+					],
 				},
 				s2: {
 					actions: {
@@ -1012,11 +1015,6 @@ describe('actions', () => {
 			},
 		});
 		const state = new CompoundState({
-			entry: [
-				{
-					actions: ['action'],
-				},
-			],
 			states: {
 				s1: new AtomicState(),
 			},
@@ -1025,6 +1023,11 @@ describe('actions', () => {
 			actions: {
 				action,
 			},
+			entry: [
+				{
+					actions: ['action'],
+				},
+			],
 		});
 		state.start();
 	});
@@ -1267,11 +1270,6 @@ describe('actions', () => {
 			},
 		});
 		const state = new CompoundState({
-			entry: [
-				{
-					actions: ['action'],
-				},
-			],
 			states: {
 				s1: new AtomicState(),
 			},
@@ -1280,6 +1278,11 @@ describe('actions', () => {
 			actions: {
 				action,
 			},
+			entry: [
+				{
+					actions: ['action'],
+				},
+			],
 		});
 		expect(state.action).toBe(null);
 		state.start();
@@ -1290,11 +1293,6 @@ describe('actions', () => {
 			run: () => 'test',
 		});
 		const state = new CompoundState({
-			entry: [
-				{
-					actions: ['action1'],
-				},
-			],
 			states: {
 				s1: new AtomicState(),
 			},
@@ -1311,6 +1309,11 @@ describe('actions', () => {
 				}),
 				action2,
 			},
+			entry: [
+				{
+					actions: ['action1'],
+				},
+			],
 		});
 		state.start();
 	});

--- a/packages/hine/tests/compound/conditions.test.js
+++ b/packages/hine/tests/compound/conditions.test.js
@@ -6,18 +6,13 @@ describe('conditions', () => {
 		const cond2 = new Condition({
 			run: () => false,
 		});
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			entry: [
 				{
 					condition: 'cond1',
 					actions: ['do'],
 				},
 			],
-			actions: {
-				do: new Action({
-					run() {},
-				}),
-			},
 			conditions: {
 				cond1: new Condition({
 					run({ ownerState }) {
@@ -33,7 +28,14 @@ describe('conditions', () => {
 				s1: new AtomicState(),
 			},
 		});
-		machine.start();
+		state.monitor({
+			actions: {
+				do: new Action({
+					run() {},
+				}),
+			},
+		});
+		state.start();
 	});
 	it('calls condition with self-reference', () => {
 		const condition = new Condition({
@@ -47,11 +49,6 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			actions: {
-				action: new Action({
-					run() {},
-				}),
-			},
 			entry: [
 				{
 					condition: 'condition',
@@ -60,6 +57,13 @@ describe('conditions', () => {
 			],
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					run() {},
+				}),
 			},
 		});
 		state.start();
@@ -77,9 +81,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -90,6 +91,11 @@ describe('conditions', () => {
 			},
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		state.start();
@@ -115,9 +121,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -129,7 +132,13 @@ describe('conditions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -154,9 +163,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -168,7 +174,13 @@ describe('conditions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -195,9 +207,6 @@ describe('conditions', () => {
 							},
 						}),
 					},
-					actions: {
-						action: new Action({ run() {} }),
-					},
 					on: {
 						event: [
 							{
@@ -211,7 +220,17 @@ describe('conditions', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					actions: {
+						action: new Action({ run() {} }),
+					},
+				},
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -237,9 +256,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -251,7 +267,13 @@ describe('conditions', () => {
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		state.subscribe(() => log.push('sub'));
 		log.length = 0;
 		state.dispatch('event');
@@ -267,9 +289,6 @@ describe('conditions', () => {
 					},
 				}),
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			on: {
 				event: [
 					{
@@ -282,6 +301,11 @@ describe('conditions', () => {
 				s1: new AtomicState(),
 			},
 		});
+		state1.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
 		expect(() => state1.start()).toThrow(/unknown condition/);
 		const state2 = new CompoundState({
 			conditions: {
@@ -291,9 +315,6 @@ describe('conditions', () => {
 						return true;
 					},
 				}),
-			},
-			actions: {
-				action: new Action({ run() {} }),
 			},
 			on: {
 				event: [
@@ -305,6 +326,11 @@ describe('conditions', () => {
 			},
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state2.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		expect(() => state2.start()).not.toThrow();
@@ -321,9 +347,6 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			entry: [
 				{
 					condition: 'condition',
@@ -332,6 +355,11 @@ describe('conditions', () => {
 			],
 			states: {
 				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
 			},
 		});
 		expect(state.condition).toBe(null);

--- a/packages/hine/tests/compound/conditions.test.js
+++ b/packages/hine/tests/compound/conditions.test.js
@@ -7,12 +7,6 @@ describe('conditions', () => {
 			run: () => false,
 		});
 		const state = new CompoundState({
-			entry: [
-				{
-					condition: 'cond1',
-					actions: ['do'],
-				},
-			],
 			conditions: {
 				cond1: new Condition({
 					run({ ownerState }) {
@@ -34,6 +28,12 @@ describe('conditions', () => {
 					run() {},
 				}),
 			},
+			entry: [
+				{
+					condition: 'cond1',
+					actions: ['do'],
+				},
+			],
 		});
 		state.start();
 	});
@@ -49,12 +49,6 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			entry: [
-				{
-					condition: 'condition',
-					actions: ['action'],
-				},
-			],
 			states: {
 				s1: new AtomicState(),
 			},
@@ -65,6 +59,12 @@ describe('conditions', () => {
 					run() {},
 				}),
 			},
+			entry: [
+				{
+					condition: 'condition',
+					actions: ['action'],
+				},
+			],
 		});
 		state.start();
 	});
@@ -347,12 +347,6 @@ describe('conditions', () => {
 			conditions: {
 				condition,
 			},
-			entry: [
-				{
-					condition: 'condition',
-					actions: ['action'],
-				},
-			],
 			states: {
 				s1: new AtomicState(),
 			},
@@ -361,6 +355,12 @@ describe('conditions', () => {
 			actions: {
 				action: new Action({ run() {} }),
 			},
+			entry: [
+				{
+					condition: 'condition',
+					actions: ['action'],
+				},
+			],
 		});
 		expect(state.condition).toBe(null);
 		state.start();

--- a/packages/hine/tests/compound/dispatch.test.js
+++ b/packages/hine/tests/compound/dispatch.test.js
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest';
 
 describe('dispatch', () => {
 	it('throws on unresolved dispatch', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new AtomicState(),
 			},
 		});
-		expect(() => machine.dispatch('test')).toThrow('Attempted dispatch before resolving state');
+		expect(() => state.dispatch('test'))
+			.toThrow('Attempted dispatch before resolving state');
 	});
 
 	it('transitions on dispatch', () => {
@@ -36,28 +37,30 @@ describe('dispatch', () => {
 				s21: new AtomicState(),
 			},
 		});
-		const compound = new CompoundState({
+		const state = new CompoundState({
 			states: { s1, s2 },
-		}).start();
-		compound.dispatch('event');
-		expect(compound.state).toBe(s2);
-		compound.dispatch('event');
-		expect(compound.state).toBe(s1);
-		compound.dispatch('event');
-		expect(compound.state).toBe(s2);
+		});
+		state.monitor({});
+		state.start();
+		state.dispatch('event');
+		expect(state.state).toBe(s2);
+		state.dispatch('event');
+		expect(state.state).toBe(s1);
+		state.dispatch('event');
+		expect(state.state).toBe(s2);
 	});
 
 	it('ignores invalid events', () => {
 		const s1 = new AtomicState();
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1,
 				s2: new AtomicState(),
 			},
 		}).start();
 		expect(() => {
-			machine.dispatch('random');
+			state.dispatch('random');
 		}).not.toThrow();
-		expect(machine.state).toBe(s1);
+		expect(state.state).toBe(s1);
 	});
 });

--- a/packages/hine/tests/compound/matches.test.js
+++ b/packages/hine/tests/compound/matches.test.js
@@ -12,16 +12,17 @@ describe('matches', () => {
 		expect(machine.matches('machine')).toBe(false);
 	});
 	it('matches state name when started', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 'machine',
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
-		expect(machine.matches('machine')).toBe(true);
+		});
+		state.start();
+		expect(state.matches('machine')).toBe(true);
 	});
 	it('matches nested states', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			name: 'machine',
 			states: {
 				s1: new CompoundState({
@@ -35,14 +36,15 @@ describe('matches', () => {
 					},
 				}),
 			},
-		}).start();
-		expect(machine.matches('machine.s1')).toBe(true);
-		expect(machine.matches('machine.s1.s11')).toBe(true);
-		expect(machine.matches('machine.s2')).toBe(false);
-		expect(machine.matches('machine.s2.s21')).toBe(false);
+		});
+		state.start();
+		expect(state.matches('machine.s1')).toBe(true);
+		expect(state.matches('machine.s1.s11')).toBe(true);
+		expect(state.matches('machine.s2')).toBe(false);
+		expect(state.matches('machine.s2.s21')).toBe(false);
 	});
 	it('matches anonymous states', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new CompoundState({
 					states: {
@@ -51,8 +53,8 @@ describe('matches', () => {
 				}),
 			},
 		}).start();
-		expect(machine.matches('.s1')).toBe(true);
-		expect(machine.matches('.s1.s11')).toBe(true);
+		expect(state.matches('.s1')).toBe(true);
+		expect(state.matches('.s1.s11')).toBe(true);
 	});
 	it('matches actions', () => {
 		const state = new CompoundState({
@@ -62,12 +64,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({
-					notifyBefore: true,
-					run() {},
-				}),
-			},
 			states: {
 				s1: new AtomicState(),
 			},
@@ -81,6 +77,14 @@ describe('matches', () => {
 			}
 			count += 1;
 		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: true,
+					run() {},
+				}),
+			},
+		});
 		state.start();
 	});
 	it('matches conditions', () => {
@@ -92,9 +96,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({
 					notifyBefore: true,
@@ -114,6 +115,11 @@ describe('matches', () => {
 			}
 			count += 1;
 		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
 		state.start();
 	});
 	it('matches handler', () => {
@@ -125,12 +131,6 @@ describe('matches', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({
-					notifyBefore: true,
-					run() {},
-				}),
-			},
 			conditions: {
 				condition: new Condition({
 					notifyBefore: true,
@@ -155,6 +155,14 @@ describe('matches', () => {
 				expect(state.matches('state.[0]')).toBe(true);
 			}
 			count += 1;
+		});
+		state.monitor({
+			actions: {
+				action: new Action({
+					notifyBefore: true,
+					run() {},
+				}),
+			},
 		});
 		state.start();
 	});

--- a/packages/hine/tests/compound/path.test.js
+++ b/packages/hine/tests/compound/path.test.js
@@ -28,7 +28,9 @@ describe('path', () => {
 				}),
 				s2,
 			},
-		}).start();
+		});
+		state.monitor({});
+		state.start();
 		expect(state.path).toEqual(['state']);
 		expect(s11.path).toEqual(['state', 's1', 's11']);
 		expect(s2.path).toEqual(['state', 's2']);
@@ -49,7 +51,9 @@ describe('path', () => {
 				}),
 				s2,
 			},
-		}).start();
+		});
+		state.monitor({});
+		state.start();
 		expect(state.path).toEqual(['']);
 		expect(s11.path).toEqual(['', 's1', 's11']);
 		expect(s2.path).toEqual(['', 's2']);

--- a/packages/hine/tests/compound/start.test.js
+++ b/packages/hine/tests/compound/start.test.js
@@ -5,12 +5,17 @@ describe('start', () => {
 	it('is resolves config idempotently', () => {
 		/** @type {string[]} */
 		const log = [];
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			always: [
 				{
 					actions: ['always'],
 				},
 			],
+			states: {
+				s1: new AtomicState(),
+			},
+		});
+		state.monitor({
 			actions: {
 				always: new Action({
 					run() {
@@ -18,12 +23,10 @@ describe('start', () => {
 					},
 				}),
 			},
-			states: {
-				s1: new AtomicState(),
-			},
-		}).start();
+		});
+		state.start();
 		expect(log).toEqual(['always']);
-		machine.start();
+		state.start();
 		expect(log).toEqual(['always', 'always']);
 	});
 	it('sets initial state', () => {
@@ -38,7 +41,7 @@ describe('start', () => {
 		expect(machine.state).toBe(state);
 	});
 	it('is resets to initial state', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new AtomicState({
 					on: {
@@ -47,11 +50,12 @@ describe('start', () => {
 				}),
 				s2: new AtomicState(),
 			},
-		}).start();
-		expect(machine.state?.name).toEqual('s1');
-		machine.dispatch('event');
-		expect(machine.state?.name).toEqual('s2');
-		machine.start();
-		expect(machine.state?.name).toEqual('s1');
+		});
+		state.start();
+		expect(state.state?.name).toEqual('s1');
+		state.dispatch('event');
+		expect(state.state?.name).toEqual('s2');
+		state.start();
+		expect(state.state?.name).toEqual('s1');
 	});
 });

--- a/packages/hine/tests/compound/subscribe.test.js
+++ b/packages/hine/tests/compound/subscribe.test.js
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 describe('subscribe', () => {
 	it('calls subscribers on start', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new CompoundState({
 					states: {
@@ -13,21 +13,16 @@ describe('subscribe', () => {
 			},
 		});
 		let count = 0;
-		machine.subscribe(() => count++);
+		state.subscribe(() => count++);
 		expect(count).toBe(1);
 
-		machine.start();
+		state.start();
 		expect(count).toBe(2);
 	});
 	it('calls subscribers on disptach', () => {
-		const machine = new CompoundState({
+		const state = new CompoundState({
 			states: {
 				s1: new CompoundState({
-					actions: {
-						noop: new Action({
-							run() {},
-						}),
-					},
 					on: {
 						event: [
 							{
@@ -40,15 +35,27 @@ describe('subscribe', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({
+			states: {
+				s1: {
+					actions: {
+						noop: new Action({
+							run() {},
+						}),
+					},
+				},
+			},
+		});
+		state.start();
 		let count = 0;
-		machine.subscribe(() => count++);
+		state.subscribe(() => count++);
 		expect(count).toBe(1);
 
-		machine.dispatch('event');
+		state.dispatch('event');
 		expect(count).toBe(2);
 
-		machine.dispatch('useless');
+		state.dispatch('useless');
 		expect(count).toBe(3);
 	});
 });

--- a/packages/hine/tests/compound/toJSON.test.js
+++ b/packages/hine/tests/compound/toJSON.test.js
@@ -81,11 +81,6 @@ describe('toJSON', () => {
 	});
 	it('serializes entry handlers', () => {
 		const state = new CompoundState({
-			entry: [
-				{
-					actions: ['action'],
-				},
-			],
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
@@ -97,6 +92,11 @@ describe('toJSON', () => {
 			actions: {
 				action: new Action({ run() {} }),
 			},
+			entry: [
+				{
+					actions: ['action'],
+				},
+			],
 		});
 		state.start();
 		const json = state.toJSON();
@@ -113,11 +113,6 @@ describe('toJSON', () => {
 	});
 	it('serializes exit handlers', () => {
 		const state = new CompoundState({
-			exit: [
-				{
-					actions: ['action'],
-				},
-			],
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
@@ -129,6 +124,11 @@ describe('toJSON', () => {
 			actions: {
 				action: new Action({ run() {} }),
 			},
+			exit: [
+				{
+					actions: ['action'],
+				},
+			],
 		});
 		state.start();
 		const json = state.toJSON();

--- a/packages/hine/tests/compound/toJSON.test.js
+++ b/packages/hine/tests/compound/toJSON.test.js
@@ -54,16 +54,19 @@ describe('toJSON', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		const json = state.toJSON();
 		expect(json.always).toEqual([
 			{
@@ -83,16 +86,19 @@ describe('toJSON', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		const json = state.toJSON();
 		expect(json.entry).toEqual([
 			{
@@ -112,16 +118,19 @@ describe('toJSON', () => {
 					actions: ['action'],
 				},
 			],
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		const json = state.toJSON();
 		expect(json.exit).toEqual([
 			{
@@ -143,16 +152,19 @@ describe('toJSON', () => {
 					},
 				],
 			},
-			actions: {
-				action: new Action({ run() {} }),
-			},
 			conditions: {
 				condition: new Condition({ run: () => true }),
 			},
 			states: {
 				s1: new AtomicState(),
 			},
-		}).start();
+		});
+		state.monitor({
+			actions: {
+				action: new Action({ run() {} }),
+			},
+		});
+		state.start();
 		const json = state.toJSON();
 		expect(json.on).toEqual({
 			event: [

--- a/packages/hine/tests/condition/path.test.js
+++ b/packages/hine/tests/condition/path.test.js
@@ -20,10 +20,9 @@ describe('path', () => {
 			name: 'action',
 			run() {},
 		});
-		new AtomicState({
-			name: 'state',
-			actions: { action },
-		}).start();
+		const state = new AtomicState({ name: 'state' });
+		state.monitor({ actions: { action }});
+		state.start();
 		expect(action.path).toEqual(['state', '(action)']);
 	});
 });

--- a/packages/hine/tests/handler/path.test.js
+++ b/packages/hine/tests/handler/path.test.js
@@ -19,7 +19,9 @@ describe('path', () => {
 		const state = new AtomicState({
 			name: 'state',
 			always: [{}],
-		}).start();
+		});
+		state.monitor({});
+		state.start();
 		// Currently the only way the end user ever reaches a Handler object
 		const eventIterator = state.step('event');
 		const { value: handler, done } = eventIterator.next();

--- a/packages/hine/tests/utils/stateEventNames.test.js
+++ b/packages/hine/tests/utils/stateEventNames.test.js
@@ -35,7 +35,9 @@ describe('stateEventNames', () => {
 					},
 				}),
 			},
-		}).start();
+		});
+		state.monitor({});
+		state.start();
 
 		expect(stateEventNames(state)).toEqual(['event', 'event11', 'event12', 'event111', 'event112']);
 		state.dispatch('event11');


### PR DESCRIPTION
Hine now requires that action definitions as well entry and exit actions be defined in an external monitor. This allows you create different side-effect implementations for the same state machine!

Before:

```javascript
const state = h.atomic({
	actions: {
		action: h.action(() => console.log('action!')),
  	}
  	entry: [{ actions: ['action'] }],
});
```

After:

```javascript
const state = h.atomic();
state.monitor({
	actions: {
		action: h.action(() => console.log('action!')),
	}
	entry: [{ actions: ['action'] }],
});
```
